### PR TITLE
Update 1.1.3_Requisite_Variety.md _Link PDF https://

### DIFF
--- a/1_Models_and_Their_Limits/1.1_Theory/1.1.3_Requisite_Variety.md
+++ b/1_Models_and_Their_Limits/1.1_Theory/1.1.3_Requisite_Variety.md
@@ -6,7 +6,7 @@
 
 ## Full Citation
 Ashby, W. Ross. (1956). *An Introduction to Cybernetics*. Chapman & Hall.  
-[Access the PDF here](sandbox:/mnt/data/Ross_Ashby_An_Introduction_to_Cybernetics.pdf)  
+[Access the PDF here](https://dn790007.ca.archive.org/0/items/introductiontocy00ashb/introductiontocy00ashb.pdf)  
 
 ## Key Concepts
 - **Requisite Variety** - Systems must match **complexity** in their environment to maintain **stability and adaptability**.  


### PR DESCRIPTION
Link "Access the PDF here", changed from sandbox to https://
Source: internet archive. PDF selected, see all download options https://archive.org/details/introductiontocy00ashb/mode/2up